### PR TITLE
embedding server templates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,8 +19,8 @@ steps:
   - name: publish
     image: plugins/buildah-ecr
     settings:
-      registry: public.ecr.aws/kanopy-sandbox
-      repo: ${DRONE_REPO_NAME}
+      registry: public.ecr.aws
+      repo: kanopy-sandbox/${DRONE_REPO_NAME}
       create_repository: true
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,10 +11,10 @@ workspace:
 
 steps:
   - name: test
-    image: golang:1.16
+    image: golangci/golangci-lint:v1.38.0-alpine
     commands:
-      - go build
-      - go test
+      - apk add make
+      - make test
 
   - name: publish
     image: plugins/kaniko-ecr

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,11 +17,10 @@ steps:
       - make test
 
   - name: publish
-    image: plugins/buildah-ecr
+    image: plugins/kaniko-ecr
     settings:
       registry: public.ecr.aws
       repo: kanopy-sandbox/${DRONE_REPO_NAME}
-      create_repository: true
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
       access_key:
@@ -30,9 +29,10 @@ steps:
         from_secret: ecr_secret_key
 
   - name: publish-tag
-    image: plugins/ecr
+    image: plugins/kaniko-ecr
     settings:
-      repo: ${DRONE_REPO_NAME}
+      registry: public.ecr.aws
+      repo: kanopy-sandbox/${DRONE_REPO_NAME}
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
         - ${DRONE_TAG}

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,9 @@ steps:
         from_secret: ecr_access_key
       secret_key:
         from_secret: ecr_secret_key
+    when:
+      event:
+        - commit
 
   - name: publish-tag
     image: plugins/ecr

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,7 @@ steps:
       create_repository: true
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
+        - latest
       access_key:
         from_secret: ecr_access_key
       secret_key:

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,8 +17,9 @@ steps:
       - go test
 
   - name: publish
-    image: plugins/ecr
+    image: plugins/kaniko-ecr
     settings:
+      registry: public.ecr.aws
       repo: public.ecr.aws/kanopy-sandbox/${DRONE_REPO_NAME}
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ steps:
     image: plugins/kaniko-ecr
     settings:
       registry: public.ecr.aws
-      repo: public.ecr.aws/kanopy-sandbox/${DRONE_REPO_NAME}
+      repo: kanopy-sandbox/${DRONE_REPO_NAME}
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
       access_key:

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
   - name: publish
     image: plugins/ecr
     settings:
-      repo: ${DRONE_REPO_NAME}
+      repo: public.ecr.aws/kanopy-sandbox/${DRONE_REPO_NAME}
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
       access_key:

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,6 +21,7 @@ steps:
     settings:
       registry: public.ecr.aws
       repo: kanopy-sandbox/${DRONE_REPO_NAME}
+      create_repository: true
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
       access_key:

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ steps:
       - make test
 
   - name: publish
-    image: plugins/kaniko-ecr
+    image: public.ecr.aws/kanopy-sandbox/kaniko-ecr:latest
     settings:
       registry: public.ecr.aws
       repo: kanopy-sandbox/${DRONE_REPO_NAME}
@@ -29,7 +29,7 @@ steps:
         from_secret: ecr_secret_key
 
   - name: publish-tag
-    image: plugins/kaniko-ecr
+    image: public.ecr.aws/kanopy-sandbox/kaniko-ecr:latest
     settings:
       registry: public.ecr.aws
       repo: kanopy-sandbox/${DRONE_REPO_NAME}

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,9 @@ kind: pipeline
 type: kubernetes
 name: default
 
+trigger:
+  event: [push, tag]
+
 workspace:
   path: /go/src/github.com/${DRONE_REPO}
 
@@ -23,9 +26,6 @@ steps:
         from_secret: ecr_access_key
       secret_key:
         from_secret: ecr_secret_key
-    when:
-      event:
-        - push
 
   - name: publish-tag
     image: plugins/ecr

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
         from_secret: ecr_secret_key
     when:
       event:
-        - commit
+        - push
 
   - name: publish-tag
     image: plugins/ecr

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,10 +17,11 @@ steps:
       - make test
 
   - name: publish
-    image: plugins/kaniko-ecr
+    image: plugins/buildah-ecr
     settings:
-      registry: public.ecr.aws
-      repo: kanopy-sandbox/${DRONE_REPO_NAME}
+      registry: public.ecr.aws/kanopy-sandbox
+      repo: ${DRONE_REPO_NAME}
+      create_repository: true
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
       access_key:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # k8s-auth-portal
+
+OIDC auth portal for Kubernetes clusters.

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
+	github.com/stretchr/testify v1.7.0
 )

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ func (s *Server) handleRoot() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := s.tmpl.ExecuteTemplate(w, "view_index.tmpl", nil); err != nil {
 			log.WithError(err).Error("error executing template")
-			w.WriteHeader(http.StatusInternalServerError)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,7 @@ func New() http.Handler {
 func (s *Server) handleRoot() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := s.tmpl.ExecuteTemplate(w, "view_index.tmpl", nil); err != nil {
-			log.Errorln("error executing template:", err)
+			log.WithError(err).Error("error executing template")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,8 +31,12 @@ func (s *Server) handleRoot() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := s.template.ExecuteTemplate(w, "view_index.tmpl", nil); err != nil {
 			log.WithError(err).Error("error executing template")
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			httpError(w, http.StatusInternalServerError)
 			return
 		}
 	}
+}
+
+func httpError(w http.ResponseWriter, code int) {
+	http.Error(w, http.StatusText(code), code)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,14 +12,14 @@ import (
 var embeddedFS embed.FS
 
 type Server struct {
-	router *http.ServeMux
-	tmpl   *template.Template
+	router   *http.ServeMux
+	template *template.Template
 }
 
 func New() http.Handler {
 	s := &Server{
-		router: http.NewServeMux(),
-		tmpl:   template.Must(template.ParseFS(embeddedFS, "templates/*.tmpl")),
+		router:   http.NewServeMux(),
+		template: template.Must(template.ParseFS(embeddedFS, "templates/*.tmpl")),
 	}
 
 	s.router.HandleFunc("/", s.handleRoot())
@@ -29,7 +29,7 @@ func New() http.Handler {
 
 func (s *Server) handleRoot() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := s.tmpl.ExecuteTemplate(w, "view_index.tmpl", nil); err != nil {
+		if err := s.template.ExecuteTemplate(w, "view_index.tmpl", nil); err != nil {
 			log.WithError(err).Error("error executing template")
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,6 +32,7 @@ func (s *Server) handleRoot() http.HandlerFunc {
 		if err := s.tmpl.ExecuteTemplate(w, "view_index.tmpl", nil); err != nil {
 			log.WithError(err).Error("error executing template")
 			w.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,7 +9,7 @@ import (
 )
 
 //go:embed templates
-var f embed.FS
+var embeddedFS embed.FS
 
 type Server struct {
 	router *http.ServeMux
@@ -19,7 +19,7 @@ type Server struct {
 func New() http.Handler {
 	s := &Server{
 		router: http.NewServeMux(),
-		tmpl:   template.Must(template.ParseFS(f, "templates/*.tmpl")),
+		tmpl:   template.Must(template.ParseFS(embeddedFS, "templates/*.tmpl")),
 	}
 
 	s.router.HandleFunc("/", s.handleRoot())

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,23 +3,21 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
+var s http.Handler
+
+func TestMain(m *testing.M) {
+	s = New()
+	os.Exit(m.Run())
+}
+
 func TestHandleRoot(t *testing.T) {
-	tests := []*http.Request{
-		httptest.NewRequest("GET", "/", nil),
-	}
-
-	s := New()
-
-	for _, req := range tests {
-		w := httptest.NewRecorder()
-
-		s.ServeHTTP(w, req)
-
-		if w.Code != 200 {
-			t.Errorf("response code %d should be 200", w.Code)
-		}
-	}
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,15 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var s http.Handler
+var testHandler http.Handler
 
 func TestMain(m *testing.M) {
-	s = New()
+	testHandler = New()
 	os.Exit(m.Run())
 }
 
 func TestHandleRoot(t *testing.T) {
 	w := httptest.NewRecorder()
-	s.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+	testHandler.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
 	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -22,7 +22,7 @@ func TestHandleRoot(t *testing.T) {
 		s.ServeHTTP(w, req)
 
 		if w.Code != 200 {
-			t.Error("test failed")
+			t.Errorf("response code %d should be 200", w.Code)
 		}
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,22 +1,19 @@
 package server
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestHandleRoot(t *testing.T) {
-	tests := []struct {
-		method string
-		path   string
-	}{
-		{method: "GET", path: "/"},
+	tests := []*http.Request{
+		httptest.NewRequest("GET", "/", nil),
 	}
 
 	s := New()
 
-	for _, test := range tests {
-		req := httptest.NewRequest(test.method, test.path, nil)
+	for _, req := range tests {
 		w := httptest.NewRecorder()
 
 		s.ServeHTTP(w, req)

--- a/internal/server/templates/includes.tmpl
+++ b/internal/server/templates/includes.tmpl
@@ -1,0 +1,16 @@
+{{ define "head" }}
+<head>
+  <title>{{ block "title" . }}k8s Portal{{ end }}</title>
+  {{ block "bootstrap_style" . }}{{end}}
+</head>
+{{ end }}
+
+{{ define "bootstrap_scripts" }}
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js" integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ" crossorigin="anonymous"></script>
+{{ end }}
+
+{{ define "bootstrap_style" }}
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
+{{ end }}

--- a/internal/server/templates/view_callback.tmpl
+++ b/internal/server/templates/view_callback.tmpl
@@ -1,0 +1,41 @@
+<html>
+{{ block "head" . }}{{end}}
+<body>
+	<div class="container">
+		<div class="card">
+		  <div class="card-body">
+				<pre><code>apiVersion: v1
+clusters:
+- cluster:
+    server: {{ .APIURL }}
+    certificate-authority-data: {{ .ClusterCAData }}
+  name: {{ .APIHostname }}
+contexts:
+- context:
+    cluster: {{ .APIHostname }}
+    namespace: {{ .Namespace }}
+    user: {{ .User }}
+  name: {{ .APIHostname }}
+current-context: {{ .APIHostname }}
+kind: Config
+preferences: {}
+users:
+- name: {{ .User }}
+  user:
+    as-user-extra: {}
+    auth-provider:
+      config:
+        client-id: {{ .ClientID }}
+        client-secret: {{ .ClientSecret }}
+        id-token: {{ .IDToken }}
+        idp-certificate-authority-data: {{ .IssuerCAData }}
+        idp-issuer-url: {{ .IssuerURL }}
+        refresh-token: {{ .RefreshToken }}
+      name: oidc
+</code></pre>
+		  </div>
+		</div>
+	</div>
+  {{ block "bootstrap_scripts" . }}{{end}}
+</body>
+</html>

--- a/internal/server/templates/view_index.tmpl
+++ b/internal/server/templates/view_index.tmpl
@@ -1,0 +1,27 @@
+<html>
+{{ block "head" . }}{{end}}
+<body>
+  <div class="container">
+    <div class="card">
+      <div class="card-body">
+        <h4 class="card-title">Step One</h4>
+        <p class="card-text">Retrieve an authorization code.</p>
+        <form class="form-inline" action="/login" method="post" target="_blank">
+          <button type="submit" class="btn btn-primary">Get Authorization Code</button>
+        </form>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body">
+        <h4 class="card-title">Step Two</h4>
+        <p class="card-text">Paste authorization code and retrieve kubectl credentials.</p>
+        <form class="form-inline" action="/callback" method="get">
+          <input name="code" type="text" class="form-control mb-2 mr-sm-2 mb-sm-0" id="inlineFormInput">
+          <button type="submit" class="btn btn-primary">Get Credentials</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  {{ block "bootstrap_scripts" . }}{{end}}
+</body>
+</html>


### PR DESCRIPTION
This copies the html templates from the existing auth portal and sets up the basic functionality to embed them into the server package using https://pkg.go.dev/embed.

Use `make docker-run` to test this locally on `localhost:8080`.
or
Run from the public registry: `docker run -p 8080:8080 public.ecr.aws/kanopy-sandbox/k8s-auth-portal:latest`

This is publishing to the sandbox public ECR registry for now. Also, this is using a fork of the `kaniko-ecr` plugin with support for repo creation. There is an upstream PR open for this: https://github.com/drone/drone-kaniko/pull/24