### PR TITLE
DEVOPS-2798 Implement CSRF handling

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -286,7 +286,7 @@ func (s *Server) handleCallback() http.HandlerFunc {
 
 		state := r.PostFormValue("state")
 		if state == "" || state != session.Values["state"] {
-			logAndError(w, http.StatusBadRequest, fmt.Errorf("expected: %v, got: %v", session.Values["state"], state), "invalid state")
+			logAndError(w, http.StatusBadRequest, fmt.Errorf("POST form and session state values do not match"), "invalid state")
 			return
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -268,7 +268,7 @@ func (s *Server) handleCallback() http.HandlerFunc {
 			return
 		}
 
-		code := r.FormValue("code")
+		code := r.PostFormValue("code")
 		if code == "" {
 			logAndError(w, http.StatusUnauthorized, fmt.Errorf("authorization code empty"), "error in authorization code")
 			return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -85,60 +86,130 @@ func TestHandleLoginGet(t *testing.T) {
 func TestHandleLoginPost(t *testing.T) {
 	t.Parallel()
 
-	w := httptest.NewRecorder()
-	server.ServeHTTP(w, httptest.NewRequest("POST", "/login", nil))
-	assert.Equal(t, http.StatusSeeOther, w.Code)
-	assert.NotEmpty(t, w.Result().Cookies()[0])
+	tests := []struct {
+		body           string
+		wantHttpStatus int
+	}{
+		{
+			// empty POST form
+			body:           "",
+			wantHttpStatus: http.StatusBadRequest,
+		},
+		{
+			// empty CSRF Token
+			body:           "csrfToken=",
+			wantHttpStatus: http.StatusBadRequest,
+		},
+		{
+			// valid CSRF Token
+			body:           "csrfToken=test-123",
+			wantHttpStatus: http.StatusSeeOther,
+		},
+	}
+
+	for _, test := range tests {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/login", strings.NewReader(test.body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		server.ServeHTTP(rr, req)
+		assert.Equal(t, test.wantHttpStatus, rr.Code)
+
+		if test.wantHttpStatus == http.StatusSeeOther {
+			assert.NotEmpty(t, rr.Result().Cookies()[0])
+		}
+	}
 }
 
 func TestHandleCallbackGet(t *testing.T) {
 	t.Parallel()
 
-	const validCallbackUrl = "/callback?code=testcode"
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, httptest.NewRequest("GET", "/callback", nil))
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestHandleCallbackPost(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validCallbackUrl = "/callback"
+		sessionCsrfToken = "test-csrf-123"
+		validAuthCode    = "test-code-123"
+	)
 	testNonce = "test-nonce-123"
 
 	tests := []struct {
 		url            string
+		body           string
 		nonce          string
 		wantHttpStatus int
 	}{
 		{
 			// success case
 			url:            validCallbackUrl,
+			body:           fmt.Sprintf("csrfToken=%s&code=%s", sessionCsrfToken, validAuthCode),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusOK,
 		},
 		{
 			// error in request URL
 			url:            "/callback?code=testcode&error=some-error",
+			body:           fmt.Sprintf("csrfToken=%s&code=%s", sessionCsrfToken, validAuthCode),
+			nonce:          testNonce,
+			wantHttpStatus: http.StatusBadRequest,
+		},
+		{
+			// no CSRF Token
+			url:            validCallbackUrl,
+			body:           fmt.Sprintf("code=%s", validAuthCode),
+			nonce:          testNonce,
+			wantHttpStatus: http.StatusBadRequest,
+		},
+		{
+			// empty CSRF Token
+			url:            validCallbackUrl,
+			body:           fmt.Sprintf("csrfToken=&code=%s", validAuthCode),
+			nonce:          testNonce,
+			wantHttpStatus: http.StatusBadRequest,
+		},
+		{
+			// POST and session CSRF Token does not match
+			url:            validCallbackUrl,
+			body:           fmt.Sprintf("csrfToken=%s&code=%s", "mismatched-csrf", validAuthCode),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusBadRequest,
 		},
 		{
 			// no authorization code
-			url:            "/callback",
+			url:            validCallbackUrl,
+			body:           fmt.Sprintf("csrfToken=%s", sessionCsrfToken),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusUnauthorized,
 		},
 		{
 			// empty authorization code
-			url:            "/callback?code=",
+			url:            validCallbackUrl,
+			body:           fmt.Sprintf("csrfToken=%s&code=", sessionCsrfToken),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusUnauthorized,
 		},
 		{
 			// nonce doesn't match expected
 			url:            validCallbackUrl,
-			nonce:          "invalid nonce",
+			body:           fmt.Sprintf("csrfToken=%s&code=%s", sessionCsrfToken, validAuthCode),
+			nonce:          "mismatched-nonce",
 			wantHttpStatus: http.StatusUnauthorized,
 		},
 	}
 
 	for _, test := range tests {
 		rr := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", test.url, nil)
+		req := httptest.NewRequest("POST", test.url, strings.NewReader(test.body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		session := server.getSession(req)
+		session.Values["csrfToken"] = sessionCsrfToken
 		session.Values["nonce"] = test.nonce
 
 		server.ServeHTTP(rr, req)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -96,13 +96,13 @@ func TestHandleLoginPost(t *testing.T) {
 			wantHttpStatus: http.StatusBadRequest,
 		},
 		{
-			// empty CSRF Token
-			body:           "csrfToken=",
+			// empty state
+			body:           "state=",
 			wantHttpStatus: http.StatusBadRequest,
 		},
 		{
-			// valid CSRF Token
-			body:           "csrfToken=test-123",
+			// valid state
+			body:           "state=test-123",
 			wantHttpStatus: http.StatusSeeOther,
 		},
 	}
@@ -134,7 +134,7 @@ func TestHandleCallbackPost(t *testing.T) {
 
 	const (
 		validCallbackUrl = "/callback"
-		sessionCsrfToken = "test-csrf-123"
+		sessionState     = "test-state-123"
 		validAuthCode    = "test-code-123"
 	)
 	testNonce = "test-nonce-123"
@@ -148,56 +148,56 @@ func TestHandleCallbackPost(t *testing.T) {
 		{
 			// success case
 			url:            validCallbackUrl,
-			body:           fmt.Sprintf("csrfToken=%s&code=%s", sessionCsrfToken, validAuthCode),
+			body:           fmt.Sprintf("state=%s&code=%s", sessionState, validAuthCode),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusOK,
 		},
 		{
 			// error in request URL
 			url:            "/callback?code=testcode&error=some-error",
-			body:           fmt.Sprintf("csrfToken=%s&code=%s", sessionCsrfToken, validAuthCode),
+			body:           fmt.Sprintf("state=%s&code=%s", sessionState, validAuthCode),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusBadRequest,
 		},
 		{
-			// no CSRF Token
+			// no state
 			url:            validCallbackUrl,
 			body:           fmt.Sprintf("code=%s", validAuthCode),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusBadRequest,
 		},
 		{
-			// empty CSRF Token
+			// empty state
 			url:            validCallbackUrl,
-			body:           fmt.Sprintf("csrfToken=&code=%s", validAuthCode),
+			body:           fmt.Sprintf("state=&code=%s", validAuthCode),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusBadRequest,
 		},
 		{
-			// POST and session CSRF Token does not match
+			// POST and session state does not match
 			url:            validCallbackUrl,
-			body:           fmt.Sprintf("csrfToken=%s&code=%s", "mismatched-csrf", validAuthCode),
+			body:           fmt.Sprintf("state=%s&code=%s", "mismatched-state", validAuthCode),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusBadRequest,
 		},
 		{
 			// no authorization code
 			url:            validCallbackUrl,
-			body:           fmt.Sprintf("csrfToken=%s", sessionCsrfToken),
+			body:           fmt.Sprintf("state=%s", sessionState),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusUnauthorized,
 		},
 		{
 			// empty authorization code
 			url:            validCallbackUrl,
-			body:           fmt.Sprintf("csrfToken=%s&code=", sessionCsrfToken),
+			body:           fmt.Sprintf("state=%s&code=", sessionState),
 			nonce:          testNonce,
 			wantHttpStatus: http.StatusUnauthorized,
 		},
 		{
 			// nonce doesn't match expected
 			url:            validCallbackUrl,
-			body:           fmt.Sprintf("csrfToken=%s&code=%s", sessionCsrfToken, validAuthCode),
+			body:           fmt.Sprintf("state=%s&code=%s", sessionState, validAuthCode),
 			nonce:          "mismatched-nonce",
 			wantHttpStatus: http.StatusUnauthorized,
 		},
@@ -209,7 +209,7 @@ func TestHandleCallbackPost(t *testing.T) {
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		session := server.getSession(req)
-		session.Values["csrfToken"] = sessionCsrfToken
+		session.Values["state"] = sessionState
 		session.Values["nonce"] = test.nonce
 
 		server.ServeHTTP(rr, req)

--- a/internal/server/templates/view_index.tmpl
+++ b/internal/server/templates/view_index.tmpl
@@ -7,7 +7,7 @@
         <h4 class="card-title">Step One</h4>
         <p class="card-text">Retrieve an authorization code.</p>
         <form class="form-inline" action="/login" method="post" target="_blank">
-          <input name="csrfToken" type="hidden" value={{ .CSRFToken }}>
+          <input name="state" type="hidden" value={{ .State }}>
           <button type="submit" class="btn btn-primary">Get Authorization Code</button>
         </form>
       </div>
@@ -18,7 +18,7 @@
         <p class="card-text">Paste authorization code and retrieve kubectl credentials.</p>
         <form class="form-inline" action="/callback" method="post">
           <input name="code" type="text" class="form-control mb-2 mr-sm-2 mb-sm-0" id="inlineFormInput">
-          <input name="csrfToken" type="hidden" value={{ .CSRFToken }}>
+          <input name="state" type="hidden" value={{ .State }}>
           <button type="submit" class="btn btn-primary">Get Credentials</button>
         </form>
       </div>

--- a/internal/server/templates/view_index.tmpl
+++ b/internal/server/templates/view_index.tmpl
@@ -7,6 +7,7 @@
         <h4 class="card-title">Step One</h4>
         <p class="card-text">Retrieve an authorization code.</p>
         <form class="form-inline" action="/login" method="post" target="_blank">
+          <input name="csrfToken" type="hidden" value={{ .CSRFToken }}>
           <button type="submit" class="btn btn-primary">Get Authorization Code</button>
         </form>
       </div>
@@ -15,8 +16,9 @@
       <div class="card-body">
         <h4 class="card-title">Step Two</h4>
         <p class="card-text">Paste authorization code and retrieve kubectl credentials.</p>
-        <form class="form-inline" action="/callback" method="get">
+        <form class="form-inline" action="/callback" method="post">
           <input name="code" type="text" class="form-control mb-2 mr-sm-2 mb-sm-0" id="inlineFormInput">
+          <input name="csrfToken" type="hidden" value={{ .CSRFToken }}>
           <button type="submit" class="btn btn-primary">Get Credentials</button>
         </form>
       </div>


### PR DESCRIPTION
Implementation to prevent CSRF attacks:
- Add a hidden form field in index.html named `state`. This is generated and populated when user visits the root page.
- When user clicks "Get Authorization Code", the POST request passes the `state` to the login handler, which saves it in a session cookie.
- When user clicks "Get Credentials", the POST request passes the `state` to the callback handler, which verifies it matches the one stored in session cookie.

Security team approved this implementation for CSRF but suggests adding additional security. A separate devops ticket was created to track the additional enhancements outside of CSRF.
https://jira.mongodb.org/browse/CORPSEC-6441