### PR TITLE
DEVOPS-2845 Add Dex IPs to /healthz failure logs

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,9 +129,6 @@ func httpClientForRootCAs(rootCABytes []byte) (*http.Client, error) {
 func (s *Server) ConfigureOpenID() error {
 	var err error
 
-	// TODO research on http Clients
-	// should this be shared/cached or constructed in each handler?
-
 	// if the client has not been overridden with a mock client
 	if s.client == nil {
 		s.client = &http.Client{
@@ -229,7 +226,7 @@ func (s *Server) getSession(r *http.Request) *sessions.Session {
 func (s *Server) getIssuerIP() []net.IP {
 	addrs, err := net.LookupIP(s.issuerURL.Host)
 	if err != nil {
-		// log error but continue to return IPs
+		// log error but continue
 		log.WithError(err).Errorf("error looking up IPs for %v", s.issuerURL.Host)
 	}
 


### PR DESCRIPTION
Due to the problems we see with the auth portal /healthz endpoint, we're adding Dex IP entries to the error logs to help debug.