### PR TITLE
DEVOPS-2823 Use public ECR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ steps:
         path: /go
     pull: always
     settings:
-      registry: public.ecr.aws/kanopy-sandbox
+      registry: public.ecr.aws/kanopy
       repo: ${DRONE_REPO_NAME}
       create_repository: true
       tags:
@@ -61,7 +61,7 @@ steps:
         path: /go
     pull: always
     settings:
-      registry: public.ecr.aws/kanopy-sandbox
+      registry: public.ecr.aws/kanopy
       repo: ${DRONE_REPO_NAME}
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}


### PR DESCRIPTION
Publish to the public kanopy ECR for k8s-auth-portal

I've updated the `ecr_access_key` and `ecr_secret_key` within [Drone settings](https://drone.corp.mongodb.com/kanopy-platform/k8s-auth-portal/settings) for the public ECR

Note I will create a separate PR for the platform repo to update minikube and test for k8s-auth-portal after this PR is merged.