### PR TITLE
DEVOPS-2870 k8s-auth-portal investigate http.Client lockups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 OIDC auth portal for Kubernetes clusters.
 
 
-## Local testing
+# Local testing
+Ensure minikube environment is up and running.
 
-Build and run the application in a local docker container
-
-    make docker-run
+Build and run the application in a local docker container.
+```
+make docker-run
+```

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -31,6 +31,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().String("issuer-url", "https://dex.example.com", "oidc issuer URL")
 	cmd.PersistentFlags().String("cluster-ca-filepath", "", "cluster CA certificate filepath")
 	cmd.PersistentFlags().String("kubectl-client-secret-filepath", "", "path to public odic client secret")
+	cmd.PersistentFlags().String("debug-url", "https://prometheus.example.com/metrics", "additional URL endpoint for debugging")
 
 	return cmd
 }
@@ -66,6 +67,7 @@ func getServerOptions() []server.ServerFuncOpt {
 		server.WithIssuerURL(viper.GetString("issuer-url")),
 		server.WithClusterCA(viper.GetString("cluster-ca-filepath")),
 		server.WithKubectlClientSecret(viper.GetString("kubectl-client-secret-filepath")),
+		server.WithDebugURL(viper.GetString("debug-url")),
 	}
 
 	return opts

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -31,7 +31,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().String("issuer-url", "https://dex.example.com", "oidc issuer URL")
 	cmd.PersistentFlags().String("cluster-ca-filepath", "", "cluster CA certificate filepath")
 	cmd.PersistentFlags().String("kubectl-client-secret-filepath", "", "path to public odic client secret")
-	cmd.PersistentFlags().String("debug-url", "https://prometheus.example.com/metrics", "additional URL endpoint for debugging")
+	cmd.PersistentFlags().String("debug-url", "https://prometheus.example.com/metrics", "additional URL endpoint for debugging") // TODO remove once http client hangup debug done
 
 	return cmd
 }

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -116,3 +116,17 @@ func WithHTTPClient(c *http.Client) ServerFuncOpt {
 		return nil
 	}
 }
+
+func WithDebugURL(debugUrl string) ServerFuncOpt {
+	return func(s *Server) error {
+		if debugUrl != "" {
+			u, err := url.ParseRequestURI(debugUrl)
+			if err != nil {
+				return err
+			}
+			s.debugURL = u
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
I'm proposing a few changes to k8s-auth-portal to help investigate http.Client lockups:

1. Set `DisableKeepAlives=true`. This prevents the TCP connection from being left open. Each time k8s-auth-portal wants to talk to Dex it needs to set up a new TCP connection, do TLS handshake, etc. I'm hoping this may be a potential solution. If this works, the rest below are not applicable.

2. When `handleHealthCheck()` fails to connect to Dex, do the following...

3. Print out HTTP lifecycle trace. Should help us confirm where HTTP is failing

4. Try to do a `s.client.Get` on another service (e.g. `https://prometheus.<cluster>.corp.mongodb.com/metrics`). This can tell us whether or not other services are accessible from k8s-auth-portal, or is it just Dex that we can't talk to.

5. Initialize a new http.Client and retry connecting to Dex "/healthz". This can tell us if we need to create a new http.Client every time in order to resolve this issue.

I'm happy to discuss the above and remove anything that isn't necessary.