### PR TITLE
DEVOPS-2883 k8s-auth-portal, add access logs to requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/coreos/go-oidc/v3 v3.0.0
+	github.com/felixge/httpsnoop v1.0.2
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
+github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -76,7 +76,7 @@ func getServerOptions() []server.ServerFuncOpt {
 func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 	addr := viper.GetString("listen-address")
 
-	log.Printf("Starting server on %s\n", addr)
+	log.Printf("Starting server on %s", addr)
 
 	opts := getServerOptions()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,9 +14,12 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/felixge/httpsnoop"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/kanopy-platform/k8s-auth-portal/pkg/random"
@@ -180,6 +183,41 @@ func (s *Server) configureResponseHeaders() {
 		"frame-ancestors 'none';" // page cannot be embedded in frame, similar to X-Frame-Options: DENY
 }
 
+func logRequestMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t := time.Now()
+
+		// Execute the chain of handlers, while capturing HTTP metrics: code, bytes-written, duration
+		metrics := httpsnoop.CaptureMetrics(next, w, r)
+
+		host := r.Header.Get("x-forwarded-for")
+		if host == "" {
+			// r.RemoteAddr contains port, which we want to remove
+			idx := strings.LastIndex(r.RemoteAddr, ":")
+			if idx == -1 {
+				host = r.RemoteAddr
+			} else {
+				host = r.RemoteAddr[:idx]
+			}
+		}
+
+		// Combined log format
+		// Using fmt.Fprintf here because logrus prints timestamps and log level by default
+		fmt.Fprintf(os.Stderr, "%v %v %v [%v] %q %v %v %q %q %vms\n",
+			host,                                   // host
+			"-",                                    // user-identity
+			"-",                                    // authuser
+			t.Format("02/Jan/2006 15:04:05 +0000"), // date
+			fmt.Sprintf("%v %v", r.Method, r.URL.Path), // request
+			metrics.Code,                    // status
+			metrics.Written,                 // bytes written
+			r.Header.Get("referer"),         // referer
+			r.Header.Get("user-agent"),      // user-agent
+			metrics.Duration.Milliseconds(), // duration of HTTP handler TODO format as int milliseconds
+		)
+	})
+}
+
 func (s *Server) commonHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for header, value := range s.reponseHeaders {
@@ -268,6 +306,7 @@ func (s *Server) clientGetWithHttpTrace(url string) error {
 }
 
 func (s *Server) routes() {
+	s.Use(logRequestMiddleware)
 	s.Use(s.commonHeadersMiddleware)
 
 	s.HandleFunc("/", s.handleRoot())


### PR DESCRIPTION
Add access logs for each request to k8s-auth-portal.
Output is combined log format

host user-identity auth-user date request status bytes-written referer user-agent handler-duration
`15.177.6.13 - - [02/Dec/2021 03:42:18 +0000] "GET /healthz" 200 15 "" "Amazon-Route53-Health-Check-Service (ref 25d67267-5610-4361-8c48-e834cdd5b06c; report http://amzn.to/1vsZADi)" 23ms`

Example logs in [Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22platform-test%22%20sourcetype%3D%22kube%3Acontainer%3Aauth%22&earliest=-30m%40m&latest=now&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=standard_perf&sid=1638417549.2490270) with changes running in test cluster