### PR TITLE
Update .drone.yml to publish arm64 image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: kubernetes
-name: default
+name: test
 
 trigger:
   branch: [main]
@@ -40,41 +40,54 @@ steps:
     when:
       event: [pull_request]
 
+---
+kind: pipeline
+name: publish-amd64
+platform:
+  arch: amd64
+
+depends_on:
+  - test
+
+trigger:
+  branch: main
+  event: [push, tag]
+
+steps:
   - name: publish
     image: plugins/kaniko-ecr
-    volumes:
-      - name: cache
-        path: /go
-    pull: always
     settings:
       registry: public.ecr.aws/kanopy
       repo: ${DRONE_REPO_NAME}
-      create_repository: true
-      tags:
-        - git-${DRONE_COMMIT_SHA:0:7}
-        - latest
+      auto_tag: true
+      auto_tag_suffix: amd64
       access_key:
         from_secret: ecr_access_key
       secret_key:
         from_secret: ecr_secret_key
-    when:
-      event: [push]
 
-  - name: publish-tag
+---
+kind: pipeline
+name: publish-arm64
+platform:
+  arch: arm64
+
+depends_on:
+  - test
+
+trigger:
+  branch: main
+  event: [push, tag]
+
+steps:
+  - name: publish
     image: plugins/kaniko-ecr
-    volumes:
-      - name: cache
-        path: /go
-    pull: always
     settings:
       registry: public.ecr.aws/kanopy
       repo: ${DRONE_REPO_NAME}
-      tags:
-        - git-${DRONE_COMMIT_SHA:0:7}
-        - ${DRONE_TAG}
+      auto_tag: true
+      auto_tag_suffix: arm64
       access_key:
         from_secret: ecr_access_key
       secret_key:
         from_secret: ecr_secret_key
-    when:
-      event: [tag]


### PR DESCRIPTION
This updates the .drone.yml pipeline to publish images for both `amd64` and `arm64` architectures. 

Although there is a drone [plugin](https://github.com/drone-plugins/drone-manifest) for creating multi-arch images, it does not currently support publishing to ECR. So for now this simply publishes suffixed images for each architecture using the `auto_tag` feature.

Auto tagging:
On `push` to `main`, images will simply be tagged with their arch instead of "latest" (`amd64`).
On `tag`, images will be checked for valid semver and tagged accordingly (`0.1-arm64`, `0.1.0-arm64`, etc.).